### PR TITLE
bump relay-hooks & wora/relay-offline version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-relay-offline",
-  "version": "1.0.0-rc.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -927,9 +927,9 @@
       "dev": true
     },
     "@restart/hooks": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.18.tgz",
-      "integrity": "sha512-pj2o4D8IETBtM3VUXbyypGapjKMchvHdn5WrJGfBj8c7dyOyx56ldgltYd+JTTS6KqbRGJVaAxN5T81D0AcZ5w=="
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.19.tgz",
+      "integrity": "sha512-8bskLEkiDvuZztnfGN+vM56q2HQV8dyXS/Eb0nhXPx6fonii3hQLxfNVA2r5NTMbvEkwDo59bAau3idUXaGvww=="
     },
     "@types/prop-types": {
       "version": "15.7.1",
@@ -982,9 +982,9 @@
       }
     },
     "@wora/offline-first": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@wora/offline-first/-/offline-first-2.0.3.tgz",
-      "integrity": "sha512-SkPF3kMJ2F+mV4hMfWRa9Cu8pYbGB1DYQivePK8Z2h6CjoLiNDXK/yDIEfJ/mC6eFcAYvwTsfHCQKlQFxjc92Q==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@wora/offline-first/-/offline-first-2.0.4.tgz",
+      "integrity": "sha512-hUEbmBe1Zq++qNbYxJ+YPJugKSsXgnRZcy8nJ145BmGDRJvPc0YqsmgLEhnYbh7GaOfTO55Ppp5JWhPWk0iKPw==",
       "requires": {
         "@wora/cache-persist": "^2.0.4",
         "@wora/netinfo": "^1.1.0",
@@ -992,12 +992,12 @@
       }
     },
     "@wora/relay-offline": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@wora/relay-offline/-/relay-offline-2.0.3.tgz",
-      "integrity": "sha512-sMjdE8Mckys8MXjBrbf6YVHuSPJK4iP1x0AjFM/kOlG+CW8xJGYOA6NzvAwSE/N6mggq5dTsfzRY/xyMegMVRQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/relay-offline/-/relay-offline-2.1.0.tgz",
+      "integrity": "sha512-5M/CwsU6sX/pGIpMfVHAnGMpomWMspSECsJHjmk15Nj7y+4k/gXJVceScVCeZE7mcjDy+3kljJJuzVWjZ5Ct0g==",
       "requires": {
         "@wora/cache-persist": "^2.0.4",
-        "@wora/offline-first": "^2.0.3",
+        "@wora/offline-first": "^2.0.4",
         "@wora/relay-store": "^2.0.3",
         "fbjs": "^1.0.0",
         "uuid": "3.3.2"
@@ -2579,7 +2579,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2600,12 +2601,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2620,17 +2623,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2747,7 +2753,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2759,6 +2766,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2773,6 +2781,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2780,12 +2789,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2804,6 +2815,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2884,7 +2896,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2896,6 +2909,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2981,7 +2995,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3017,6 +3032,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3036,6 +3052,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3079,12 +3096,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5309,9 +5328,9 @@
       }
     },
     "relay-hooks": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/relay-hooks/-/relay-hooks-2.0.0.tgz",
-      "integrity": "sha512-QEBJauHWdZs38ZOnQ37H/hQOhnyDAtb5DcdKF7TKxZPny6Onus1c/vyPhHQPOtIgtfF8Wd7PqyiENFGsapmZHw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/relay-hooks/-/relay-hooks-2.1.0.tgz",
+      "integrity": "sha512-s+ut/4V8ethjQCE/dsJ0O9JpM1esawNRcgIimRbRSrL89gIwShDeIQOoFIj5Gb6p6VwU7z3pQb1Jx0TweSoEWg==",
       "requires": {
         "@restart/hooks": "^0.3.1",
         "fbjs": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-relay-offline",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "keywords": [
     "graphql",
     "relay",
@@ -21,16 +21,16 @@
   "scripts": {
     "clean": "rimraf lib/*",
     "prepare": "npm run build",
-    "build": "tsc"
+    "build": "npm run clean && tsc"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@wora/relay-offline": "^2.0.4",
+    "@wora/relay-offline": "^2.1.0",
     "@wora/detect-network": "^1.3.0",
     "fbjs": "^1.0.0",
     "nullthrows": "^1.1.0",
     "uuid": "3.3.2",
-    "relay-hooks": "2.0.0"
+    "relay-hooks": "^2.1.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/src/RelayOfflineTypes.ts
+++ b/src/RelayOfflineTypes.ts
@@ -1,5 +1,5 @@
 import { OperationType, CacheConfig, GraphQLTaggedNode } from "relay-runtime";
-import { FetchPolicy, RenderProps } from "relay-hooks/lib/RelayHooksType";
+import { FetchPolicy, RenderProps } from "relay-hooks";
 
 export interface QueryRendererProps<T> extends QueryProps<T> {
   render: (renderProps: RenderProps<T>) => React.ReactNode;

--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -3,7 +3,7 @@ import { ReactRelayContext } from "react-relay";
 import { RelayContext } from "relay-runtime";
 import * as areEqual from "fbjs/lib/areEqual";
 import { OfflineRecordCache } from "@wora/offline-first";
-import { Payload } from "@wora/relay-offline/lib/OfflineFirstRelay";
+import { Payload } from "@wora/relay-offline";
 
 function useOffline() {
   const ref = useRef();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,7 @@ export {
   STORE_THEN_NETWORK,
   STORE_OR_NETWORK,
   STORE_ONLY,
-  FetchPolicy
-} from "relay-hooks/lib/RelayHooksType";
-
-export {
+  FetchPolicy,
   useFragment,
   useMutation,
   useOssFragment,
@@ -58,7 +55,6 @@ export { default as fetchQuery } from "./runtime/fetchQuery";
 export { Environment } from "@wora/relay-offline";
 export { Store } from "@wora/relay-store";
 export { RecordSource } from "@wora/relay-store";
-export { OfflineStore } from "@wora/relay-offline";
 export { NetInfo } from "@wora/detect-network";
 export { useNetInfo } from "@wora/detect-network";
 export { useIsConnected } from "@wora/detect-network";


### PR DESCRIPTION
[wora/relay-offline 2.1.0](https://github.com/morrys/wora/releases/tag/relay-offline%402.1.0)
[relay-hooks 2.1.0](https://github.com/relay-tools/relay-hooks/releases/tag/v2.1.0)