### PR TITLE
Support netinfo5 & expo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-relay-offline",
-  "version": "2.0.0-rc.4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6628,59 +6628,58 @@
       }
     },
     "@wora/cache-persist": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@wora/cache-persist/-/cache-persist-2.0.4.tgz",
-      "integrity": "sha512-EdpoGFMdAQ1AseO7XBaIJ2IipRSLFy4bmMk6B6VysDIOth3VaIlQuXyxxV5CTnOyyZfZ2drPvnw/XsVfDDUMvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/cache-persist/-/cache-persist-2.1.0.tgz",
+      "integrity": "sha512-oOuzWyqXhFQ9eixepzRusGS/WmeF5SrFjV6KEPl4Qxrk7hHICKhR4AoF0gHl5HzIX8Ao3grUtiRmYzqQiFwiNQ==",
       "requires": {
         "idb": "^4.0.0"
       }
     },
     "@wora/detect-network": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@wora/detect-network/-/detect-network-1.3.1.tgz",
-      "integrity": "sha512-bYVMrT7HKSLhD1wNTti50pPLgJiWo40G+ICh3prMfZZIdE24mwIuBiHOQH+9ENGn48YhLOEvAQN8u2VT86Ju9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wora/detect-network/-/detect-network-2.0.0.tgz",
+      "integrity": "sha512-YEXuy2b/kKLr2KJ4OrfPJn6oADFbjD0vRPhJdC+U2as8QnYpF8IlxrFBzkcfiTolLFb71tB9jwcihFb2xB4mwQ==",
       "requires": {
-        "@wora/netinfo": "^1.1.1"
+        "@wora/netinfo": "^2.0.0"
       }
     },
     "@wora/netinfo": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@wora/netinfo/-/netinfo-1.1.1.tgz",
-      "integrity": "sha512-PVzITUdW0xCnN4CyWvf3CN4IqWYePEcHZ/Nk920+UZvG+3kmvcXgZAODushcF4gv6A+oSehR22OfTl3hX3G7rg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wora/netinfo/-/netinfo-2.0.0.tgz",
+      "integrity": "sha512-Yw+ELfv6k8VMAV+NxwgzCvHewpaQbLLhZfBSDwklDcpvdwvZC+0lvvtzHYNtXTMINKML6wtvcaP5WOk1sKOPxQ==",
       "requires": {
-        "array-find-index": "1.0.2",
         "fbjs": "^1.0.0"
       }
     },
     "@wora/offline-first": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@wora/offline-first/-/offline-first-2.0.5.tgz",
-      "integrity": "sha512-tmlYi1mdcRTiGLETdiIUwq3igsX2bas7Qa07PEGNq4NFFkRzabJfos2YuKn6r0Pl/tWS0w0Jt7q+RXmxyeis4A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/offline-first/-/offline-first-2.1.0.tgz",
+      "integrity": "sha512-6LaAHEfCPmH8Kyp9T3EmwyarXmHrzisgy2nbWU5VzO9E6P671oUkcb8wU4tq/qeB5arsZdq+subeLCMm+UE8cw==",
       "requires": {
-        "@wora/cache-persist": "^2.0.4",
-        "@wora/netinfo": "^1.1.1",
+        "@wora/cache-persist": "^2.1.0",
+        "@wora/netinfo": "^2.0.0",
         "fbjs": "^1.0.0"
       }
     },
     "@wora/relay-offline": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wora/relay-offline/-/relay-offline-3.0.1.tgz",
-      "integrity": "sha512-Th4kh+7PxAIqKzdVMn6lQ6cdkKKKGcxE4Sn1Tvpeueaa7cou4vUj5HtjivL6ujilV3uyWa61ljpILAEvdBBmRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/relay-offline/-/relay-offline-3.1.0.tgz",
+      "integrity": "sha512-LP7YYsuVMC9vLlvOIJwQRN0kpMgWMiEQTH9kpJcvZNYL4C9PbFzTlB4026QK7xFDwiq89wdf1yIAHtZ1IArVlA==",
       "requires": {
-        "@wora/cache-persist": "^2.0.4",
-        "@wora/offline-first": "^2.0.5",
-        "@wora/relay-store": "^3.0.1",
+        "@wora/cache-persist": "^2.1.0",
+        "@wora/offline-first": "^2.1.0",
+        "@wora/relay-store": "^3.1.0",
         "fbjs": "^1.0.0",
         "tslib": "^1.11.1",
         "uuid": "3.3.2"
       }
     },
     "@wora/relay-store": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wora/relay-store/-/relay-store-3.0.1.tgz",
-      "integrity": "sha512-EyAeRVDr1aA41jA1s0j7VX/0/pWW+01LrhdCbzmT+37sxOj0pVg9g1i/VmBZwy9m5v+TCuhArA4Tp2TkOdFczA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/relay-store/-/relay-store-3.1.0.tgz",
+      "integrity": "sha512-iKvVqit6NjdYQ7MxGzZUyP2lxMOqPftg/Rmsrgo8hGFh6ruIQS3fCNrKL+hV8pcZnHKYYgzqayXJWRrqOLRwRg==",
       "requires": {
-        "@wora/cache-persist": "^2.0.4",
+        "@wora/cache-persist": "^2.1.0",
         "tslib": "^1.11.1"
       }
     },
@@ -7234,7 +7233,8 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "array-ify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-relay-offline",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "keywords": [
     "graphql",
     "relay",
@@ -29,11 +29,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@wora/relay-offline": "^3.0.1",
-    "@wora/detect-network": "^1.3.1",
-    "@wora/cache-persist": "^2.0.4",
-    "@wora/offline-first": "^2.0.5",
-    "@wora/relay-store": "^3.0.1",
+    "@wora/relay-offline": "^3.1.0",
+    "@wora/netinfo": "^2.0.0",
+    "@wora/detect-network": "^2.0.0",
+    "@wora/cache-persist": "^2.1.0",
+    "@wora/offline-first": "^2.1.0",
+    "@wora/relay-store": "^3.1.0",
     "fbjs": "^1.0.0",
     "nullthrows": "^1.1.0",
     "uuid": "3.3.2",

--- a/src/QueryRendererHook.tsx
+++ b/src/QueryRendererHook.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { QueryRendererProps } from './RelayOfflineTypes';
-import useQueryOffline from './hooks/useQueryOffline';
+import { useQueryOffline } from './hooks/useQueryOffline';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const QueryRendererHook = <T extends {}>(props: QueryRendererProps<T>) => {
+export const QueryRendererHook = <T extends {}>(props: QueryRendererProps<T>) => {
     const { render, fetchPolicy, query, variables, cacheConfig, ttl } = props;
     const hooksProps = useQueryOffline(query, variables, {
         networkCacheConfig: cacheConfig,
@@ -13,5 +13,3 @@ const QueryRendererHook = <T extends {}>(props: QueryRendererProps<T>) => {
 
     return <React.Fragment>{render(hooksProps)}</React.Fragment>;
 };
-
-export default QueryRendererHook;

--- a/src/QueryRendererOffline.tsx
+++ b/src/QueryRendererOffline.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import QueryRenderer from './QueryRendererHook';
+import { QueryRendererHook } from './QueryRendererHook';
 import { RelayEnvironmentProvider } from 'relay-hooks';
 import { QueryRendererOfflineProps } from './RelayOfflineTypes';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const QueryRendererOffline = function <T>(props: QueryRendererOfflineProps<T>) {
+export const QueryRendererOffline = function <T>(props: QueryRendererOfflineProps<T>) {
     const { environment } = props;
 
     return (
         <RelayEnvironmentProvider environment={environment}>
-            <QueryRenderer {...props} />
+            <QueryRendererHook {...props} />
         </RelayEnvironmentProvider>
     );
 };
-
-export default QueryRendererOffline;

--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -5,7 +5,7 @@ import * as areEqual from 'fbjs/lib/areEqual';
 import { OfflineRecordCache } from '@wora/offline-first';
 import { Payload } from '@wora/relay-offline';
 
-function useOffline(): ReadonlyArray<OfflineRecordCache<Payload>> {
+export function useOffline(): ReadonlyArray<OfflineRecordCache<Payload>> {
     const ref = useRef();
     const { environment }: RelayContext = useContext(ReactRelayContext);
     const [state, setState] = useState<ReadonlyArray<OfflineRecordCache<Payload>>>(environment.getStoreOffline().getListMutation());
@@ -24,5 +24,3 @@ function useOffline(): ReadonlyArray<OfflineRecordCache<Payload>> {
 
     return state;
 }
-
-export default useOffline;

--- a/src/hooks/useQueryOffline.ts
+++ b/src/hooks/useQueryOffline.ts
@@ -6,7 +6,7 @@ import { CacheConfig } from 'relay-runtime';
 import { OfflineRenderProps } from '../RelayOfflineTypes';
 import { useMemoOperationDescriptor } from 'relay-hooks/lib/useQuery';
 
-const useQueryOffline = function <TOperationType extends OperationType>(
+export const useQueryOffline = function <TOperationType extends OperationType>(
     gqlQuery: GraphQLTaggedNode,
     variables: TOperationType['variables'],
     options: {
@@ -67,5 +67,3 @@ const useQueryOffline = function <TOperationType extends OperationType>(
         error: error,
     };
 };
-
-export default useQueryOffline;

--- a/src/hooks/useRestore.ts
+++ b/src/hooks/useRestore.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-function useRestore(environment): boolean {
+export function useRestore(environment): boolean {
     const [rehydratate, setRehydratate] = useState(environment.isRehydrated());
 
     if (!rehydratate) {
@@ -8,5 +8,3 @@ function useRestore(environment): boolean {
     }
     return rehydratate;
 }
-
-export default useRestore;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,10 +48,11 @@ export {
     RelayEnvironmentProvider,
 } from 'relay-hooks';
 
-export { default as QueryRenderer } from './QueryRendererOffline';
-export { default as useRestore } from './hooks/useRestore';
-export { default as useQuery } from './hooks/useQueryOffline';
+export { QueryRendererOffline as QueryRenderer } from './QueryRendererOffline';
+export { useRestore } from './hooks/useRestore';
+export { useQueryOffline as useQuery } from './hooks/useQueryOffline';
 export { default as fetchQuery } from './runtime/fetchQuery';
 export { Environment } from '@wora/relay-offline';
 export { Store, RecordSource } from '@wora/relay-store';
-export { NetInfo, useNetInfo, useIsConnected } from '@wora/detect-network';
+export { NetInfo } from '@wora/netinfo';
+export { useNetInfo, useIsConnected } from '@wora/detect-network';


### PR DESCRIPTION
updated the "wora" dependencies https://github.com/morrys/wora/pull/52 and removed the use of export defaults https://github.com/morrys/react-relay-offline/issues/42
